### PR TITLE
fix: WordPress JetPack がサイトヘルスで出力したエラーを 2 件解消する

### DIFF
--- a/roles/nginx/templates/default.conf.j2
+++ b/roles/nginx/templates/default.conf.j2
@@ -34,6 +34,7 @@ server {
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Forwarded-Server $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Port $server_port;
     proxy_cache_valid 200 404 1d;
 
     location ~ /\. {deny all; access_log off; log_not_found off; }


### PR DESCRIPTION
エラー内容

> oki2a24 is not connected.: 200
> Jetpack
> Jetpack サポートにお問い合わせください。

> 想定外のサーバーポート値です。
> Jetpack
> お使いの wp-config.php ファイルに次の記述を追加してみてください。 define( ‘JETPACK_SIGNATURE__HTTPS_PORT’, 0 );