### PR TITLE
feat: php-intl をインストールする

### DIFF
--- a/roles/php/tasks/install_php.yml
+++ b/roles/php/tasks/install_php.yml
@@ -33,6 +33,7 @@
       - php-fileinfo
       - php-hash
       - php-imagick
+      - php-intl
       - php-json
       - php-mbstring
       - php-mysqli


### PR DESCRIPTION
WordPress サイトヘルスで "オプションのモジュール intl がインストールされていないか、無効化されています。" とあったため。